### PR TITLE
feat: integrate summarized reviews into product and library components

### DIFF
--- a/src/modules/home/ui/components/search-filters/search-input.tsx
+++ b/src/modules/home/ui/components/search-filters/search-input.tsx
@@ -29,7 +29,7 @@ export const SearchInput = ({ disabled }: SearchInputProps) => {
 					disabled={disabled}
 				/>
 			</div>
-			{/* TODO: Add categories view all button */}
+
 			<Button
 				variant={"elevated"}
 				className="size-12 shrink-0 flex lg:hidden"
@@ -39,7 +39,7 @@ export const SearchInput = ({ disabled }: SearchInputProps) => {
 			>
 				<ListFilterIcon />
 			</Button>
-			{/* TODO: Add library button */}
+
 			{session.data?.user && (
 				<Button asChild variant={"elevated"}>
 					<Link prefetch href="/library">

--- a/src/modules/library/server/procedures.ts
+++ b/src/modules/library/server/procedures.ts
@@ -1,54 +1,11 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { DEFAULT_PAGINATION_LIMIT, MAX_PAGINATION_LIMIT } from "~/constants";
+import { getSummarisedReviews } from "~/modules/reviews/servers/helpers";
 import type { Media, Tenant } from "~/payload-types";
 import { createTRPCRouter, protectedProcedure } from "~/trpc/init";
 
 export const libraryRouter = createTRPCRouter({
-	getMany: protectedProcedure
-		.input(
-			z.object({
-				cursor: z.number().min(1).default(1),
-				limit: z
-					.number()
-					.max(MAX_PAGINATION_LIMIT)
-					.default(DEFAULT_PAGINATION_LIMIT),
-			}),
-		)
-		.query(async ({ ctx, input }) => {
-			const ordersData = await ctx.payload.find({
-				collection: "orders",
-				depth: 0, // Just ids without populating
-				where: {
-					user: {
-						equals: ctx.session.user.id,
-					},
-				},
-				page: input.cursor,
-				limit: input.limit,
-			});
-
-			const productIds = ordersData.docs.map((order) => order.product);
-
-			const productsData = await ctx.payload.find({
-				collection: "products",
-				pagination: false,
-				where: {
-					id: {
-						in: productIds,
-					},
-				},
-			});
-
-			return {
-				...productsData,
-				docs: productsData.docs.map((doc) => ({
-					...doc,
-					image: doc.image as unknown as Media | null,
-					tenant: doc.tenant as unknown as Tenant & { image: Media | null },
-				})),
-			};
-		}),
 	getOne: protectedProcedure
 		.input(
 			z.object({
@@ -98,5 +55,54 @@ export const libraryRouter = createTRPCRouter({
 			}
 
 			return product;
+		}),
+	getMany: protectedProcedure
+		.input(
+			z.object({
+				cursor: z.number().min(1).default(1),
+				limit: z
+					.number()
+					.max(MAX_PAGINATION_LIMIT)
+					.default(DEFAULT_PAGINATION_LIMIT),
+			}),
+		)
+		.query(async ({ ctx, input }) => {
+			const ordersData = await ctx.payload.find({
+				collection: "orders",
+				depth: 0, // Just ids without populating
+				where: {
+					user: {
+						equals: ctx.session.user.id,
+					},
+				},
+				page: input.cursor,
+				limit: input.limit,
+			});
+
+			const productIds = ordersData.docs.map((order) => order.product);
+
+			const productsData = await ctx.payload.find({
+				collection: "products",
+				pagination: false,
+				where: {
+					id: {
+						in: productIds,
+					},
+				},
+			});
+
+			const dataWithSummarisedReviews = await getSummarisedReviews(
+				productsData,
+				ctx.payload,
+			);
+
+			return {
+				...productsData,
+				docs: dataWithSummarisedReviews.map((doc) => ({
+					...doc,
+					image: doc.image as unknown as Media | null,
+					tenant: doc.tenant as unknown as Tenant & { image: Media | null },
+				})),
+			};
 		}),
 });

--- a/src/modules/library/ui/components/product-list.tsx
+++ b/src/modules/library/ui/components/product-list.tsx
@@ -42,8 +42,8 @@ export const ProductList = () => {
 							imageUrl={product.image?.url}
 							tenantSlug={product.tenant?.slug}
 							tenantImageUrl={product.tenant?.image?.url}
-							reviewRating={3}
-							reviewCount={5}
+							reviewRating={product.reviewRating}
+							reviewCount={product.reviewCount}
 						/>
 					))}
 			</div>

--- a/src/modules/products/server/procedures.ts
+++ b/src/modules/products/server/procedures.ts
@@ -3,6 +3,7 @@ import type { Sort, Where } from "payload";
 import { z } from "zod";
 import { DEFAULT_PAGINATION_LIMIT, MAX_PAGINATION_LIMIT } from "~/constants";
 import { sortValues } from "~/modules/products/search-params";
+import { getSummarisedReviews } from "~/modules/reviews/servers/helpers";
 import type { Category, Media, Tenant } from "~/payload-types";
 import { baseProcedure, createTRPCRouter } from "~/trpc/init";
 
@@ -50,11 +51,56 @@ export const productsRouter = createTRPCRouter({
 				isPurchased = ordersData.totalDocs > 0;
 			}
 
+			const reviewsData = await ctx.payload.find({
+				collection: "reviews",
+				pagination: false,
+				where: {
+					product: {
+						equals: input.id,
+					},
+				},
+			});
+
+			const reviewRating =
+				reviewsData.docs.length > 0
+					? reviewsData.docs.reduce((acc, review) => acc + review.rating, 0) /
+						reviewsData.totalDocs
+					: 0;
+
+			const ratingDistribution: Record<number, number> = {
+				5: 0,
+				4: 0,
+				3: 0,
+				2: 0,
+				1: 0,
+			};
+
+			if (reviewsData.totalDocs > 0) {
+				for (const review of reviewsData.docs) {
+					const rating = review.rating;
+
+					if (rating >= 1 && rating <= 5) {
+						ratingDistribution[rating] = (ratingDistribution[rating] ?? 0) + 1;
+					}
+				}
+
+				for (const key in Object.keys(ratingDistribution)) {
+					const rating = Number(key);
+					const count = ratingDistribution[rating] || 0;
+					ratingDistribution[rating] = Math.round(
+						(count / reviewsData.totalDocs) * 100,
+					);
+				}
+			}
+
 			return {
 				...product,
 				image: product.image as unknown as Media | null,
 				tenant: product.tenant as unknown as Tenant & { image: Media | null },
 				isPurchased,
+				reviewRating,
+				reviewCount: reviewsData.totalDocs,
+				ratingDistribution,
 			};
 		}),
 	getMany: baseProcedure
@@ -163,9 +209,13 @@ export const productsRouter = createTRPCRouter({
 				limit: input.limit,
 			});
 
+			const dataWithSummarisedReviews = await getSummarisedReviews(
+				data,
+				ctx.payload,
+			);
 			return {
 				...data,
-				docs: data.docs.map((doc) => ({
+				docs: dataWithSummarisedReviews.map((doc) => ({
 					...doc,
 					image: doc.image as unknown as Media | null,
 					tenant: doc.tenant as unknown as Tenant & { image: Media | null },

--- a/src/modules/products/ui/components/product-card.tsx
+++ b/src/modules/products/ui/components/product-card.tsx
@@ -4,8 +4,6 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { formatCurrency, generateTenantURL } from "~/lib/utils";
 
-// TODO: Add real ratings
-
 interface ProductCardProps {
 	id: string;
 	name: string;
@@ -48,7 +46,7 @@ export const ProductCard = ({
 				</div>
 				<div className="p-4 border-y flex flex-col gap-3 flex-1">
 					<h2 className="text-lg font-medium line-clamp-4">{name}</h2>
-					{/* Todo: redirect to user shop */}
+
 					<button
 						type="button"
 						className="flex items-center gap-2 cursor-pointer hover:opacity-50"

--- a/src/modules/products/ui/components/product-list.tsx
+++ b/src/modules/products/ui/components/product-list.tsx
@@ -61,8 +61,8 @@ export const ProductList = ({
 							imageUrl={product.image?.url}
 							tenantSlug={product.tenant?.slug}
 							tenantImageUrl={product.tenant?.image?.url}
-							reviewRating={3}
-							reviewCount={5}
+							reviewRating={product.reviewRating}
+							reviewCount={product.reviewCount}
 							price={product.price}
 						/>
 					))}

--- a/src/modules/products/ui/views/product-view.tsx
+++ b/src/modules/products/ui/views/product-view.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { LinkIcon, StarIcon } from "lucide-react";
-// TODO: Add real ratings
+import { Check, LinkIcon, StarIcon } from "lucide-react";
 import dynamic from "next/dynamic";
 import Image from "next/image";
 import Link from "next/link";
-import { Fragment } from "react";
+import { Fragment, useState } from "react";
+import { toast } from "sonner";
 import { StarRating } from "~/components/star-rating";
 import { Button } from "~/components/ui/button";
 import { Progress } from "~/components/ui/progress";
@@ -42,6 +42,8 @@ export const ProductView = ({ productId, tenantSlug }: ProductViewProps) => {
 			id: productId,
 		}),
 	);
+
+	const [isCopied, setIsCopied] = useState(false);
 
 	return (
 		<div className="px-4 lg:px-12 py-10">
@@ -87,8 +89,12 @@ export const ProductView = ({ productId, tenantSlug }: ProductViewProps) => {
 								</Link>
 							</div>
 							<div className="hidden lg:flex px-6 py-4 items-center justify-center">
-								<div className="flex items-center gap-1">
-									<StarRating rating={3} />
+								<div className="flex items-center gap-2">
+									<StarRating rating={data.reviewRating} />
+									<p className="text-base font-medium">
+										{data.reviewCount}{" "}
+										{data.reviewCount === 1 ? "rating" : "ratings"}
+									</p>
 								</div>
 							</div>
 						</div>
@@ -96,9 +102,12 @@ export const ProductView = ({ productId, tenantSlug }: ProductViewProps) => {
 						{/* Mobile only  */}
 
 						<div className="block lg:hidden px-6 py-4 items-center justify-center border-b">
-							<div className="flex items-center gap-1">
-								<StarRating rating={3} />
-								<p className="text-base font-medium">{5} ratings</p>
+							<div className="flex items-center gap-2">
+								<StarRating rating={data.reviewRating} />
+								<p className="text-base font-medium">
+									{data.reviewCount}{" "}
+									{data.reviewCount === 1 ? "rating" : "ratings"}
+								</p>
 							</div>
 						</div>
 
@@ -126,10 +135,20 @@ export const ProductView = ({ productId, tenantSlug }: ProductViewProps) => {
 									<Button
 										className="size-12"
 										variant={"elevated"}
-										onClick={() => {}}
-										disabled={false}
+										onClick={() => {
+											navigator.clipboard.writeText(window.location.href);
+											toast.success("Link copied to clipboard");
+
+											setTimeout(() => {
+												setIsCopied(false);
+											}, 2000);
+										}}
+										disabled={isCopied}
 									>
-										<LinkIcon />
+										{isCopied ? <Check /> : <LinkIcon />}
+										<span className="sr-only">
+											{isCopied ? "Link copied to clipboard" : "Copy link"}
+										</span>
 									</Button>
 								</div>
 								<p className="text-center font-medium">
@@ -143,9 +162,12 @@ export const ProductView = ({ productId, tenantSlug }: ProductViewProps) => {
 									<h3 className="text-xl font-medium">Ratings</h3>
 									<div className="flex items-center gap-x-1 font-medium">
 										<StarIcon className="size-4 fill-black" />
-										<p>({5})</p>
+										<p>({data.reviewRating})</p>
 
-										<p className="text-base">{5} ratings</p>
+										<p className="text-base">
+											{data.reviewCount}{" "}
+											{data.reviewCount === 1 ? "rating" : "ratings"}
+										</p>
 									</div>
 								</div>
 
@@ -155,8 +177,13 @@ export const ProductView = ({ productId, tenantSlug }: ProductViewProps) => {
 											<p className="font-medium">
 												{stars} {stars === 1 ? "star" : "stars"}
 											</p>
-											<Progress value={25} className="h-[1lh]" />
-											<div className="font-medium">{25}%</div>
+											<Progress
+												value={data.ratingDistribution[stars] ?? 0}
+												className="h-[1lh]"
+											/>
+											<div className="font-medium">
+												{data.ratingDistribution[stars] ?? 0}%
+											</div>
 										</Fragment>
 									))}
 								</div>

--- a/src/modules/reviews/servers/helpers.ts
+++ b/src/modules/reviews/servers/helpers.ts
@@ -1,0 +1,33 @@
+import type { PaginatedDocs, Payload } from "payload";
+import type { Product } from "~/payload-types";
+
+export const getSummarisedReviews = async (
+	products: PaginatedDocs<Product>,
+	payload: Payload,
+) => {
+	const dataWithSummarisedReviews = await Promise.all(
+		products.docs.map(async (doc) => {
+			const reviewsData = await payload.find({
+				collection: "reviews",
+				pagination: false,
+				where: {
+					product: {
+						equals: doc.id,
+					},
+				},
+			});
+
+			return {
+				...doc,
+				reviewCount: reviewsData.totalDocs,
+				reviewRating:
+					reviewsData.docs.length === 0
+						? 0
+						: reviewsData.docs.reduce((acc, review) => acc + review.rating, 0) /
+							reviewsData.totalDocs,
+			};
+		}),
+	);
+
+	return dataWithSummarisedReviews;
+};


### PR DESCRIPTION
- Added `getSummarisedReviews` helper to fetch and calculate review ratings and counts for products.
- Updated `libraryRouter` to include summarized reviews in the `getMany` query.
- Modified `ProductList` and `ProductView` components to display dynamic review ratings and counts.
- Removed placeholder review data in favor of actual review metrics.