### PR TITLE
feat: enhance access control and add new fields to collections

### DIFF
--- a/src/collections/Categories.ts
+++ b/src/collections/Categories.ts
@@ -1,9 +1,17 @@
 import type { CollectionConfig } from "payload";
+import { isSuperAdmin } from "~/lib/access";
 
 export const Categories: CollectionConfig = {
 	slug: "categories",
+	access: {
+		read: () => true,
+		create: ({ req }) => isSuperAdmin(req.user),
+		update: ({ req }) => isSuperAdmin(req.user),
+		delete: ({ req }) => isSuperAdmin(req.user),
+	},
 	admin: {
 		useAsTitle: "name",
+		hidden: ({ user }) => !isSuperAdmin(user),
 	},
 	fields: [
 		{

--- a/src/collections/Media.ts
+++ b/src/collections/Media.ts
@@ -1,9 +1,15 @@
 import type { CollectionConfig } from "payload";
+import { isSuperAdmin } from "~/lib/access";
 
 export const Media: CollectionConfig = {
 	slug: "media",
 	access: {
 		read: () => true,
+		delete: ({ req }) => isSuperAdmin(req.user),
+	},
+	admin: {
+		// No need to show media collection to non-super admins, it's just confusing for them
+		hidden: ({ user }) => !isSuperAdmin(user),
 	},
 	fields: [
 		{

--- a/src/collections/Orders.ts
+++ b/src/collections/Orders.ts
@@ -1,7 +1,18 @@
 import type { CollectionConfig } from "payload";
+import { isSuperAdmin } from "~/lib/access";
 
 export const Orders: CollectionConfig = {
 	slug: "orders",
+	access: {
+		read: ({ req }) => isSuperAdmin(req.user),
+		create: ({ req }) => isSuperAdmin(req.user),
+		update: ({ req }) => isSuperAdmin(req.user),
+		delete: ({ req }) => isSuperAdmin(req.user),
+	},
+	admin: {
+		useAsTitle: "name",
+		hidden: ({ user }) => !isSuperAdmin(user),
+	},
 	fields: [
 		{
 			name: "name",
@@ -26,6 +37,9 @@ export const Orders: CollectionConfig = {
 			name: "stripeCheckoutSessionId",
 			type: "text",
 			required: true,
+			admin: {
+				description: "Stripe checkout session associated with this order",
+			},
 		},
 	],
 };

--- a/src/collections/Products.ts
+++ b/src/collections/Products.ts
@@ -1,7 +1,23 @@
 import type { CollectionConfig } from "payload";
+import { isSuperAdmin } from "~/lib/access";
+import type { Tenant } from "~/payload-types";
 
 export const Products: CollectionConfig = {
 	slug: "products",
+	access: {
+		create: ({ req }) => {
+			if (isSuperAdmin(req.user)) {
+				return true;
+			}
+
+			// Tenants must have submitted stripe details to create products
+			const tenant = req.user?.tenants?.[0]?.tenant as Tenant;
+
+			return Boolean(tenant?.stripeDetailsSubmitted);
+		},
+		update: ({ req }) => isSuperAdmin(req.user),
+		delete: ({ req }) => isSuperAdmin(req.user),
+	},
 	admin: {
 		useAsTitle: "name",
 	},
@@ -12,6 +28,7 @@ export const Products: CollectionConfig = {
 			required: true,
 		},
 		{
+			// TODO: Change to rich text
 			name: "description",
 			type: "text",
 		},
@@ -46,6 +63,15 @@ export const Products: CollectionConfig = {
 			type: "select",
 			options: ["30-day", "14-day", "7-day", "3-day", "1-day", "no-refunds"],
 			defaultValue: "30-day",
+		},
+		{
+			name: "content",
+			// TODO: Change to rich text
+			type: "textarea",
+			admin: {
+				description:
+					"Protected content only visible to customers after purchase. Add product documentation, downloadable files, getting started guides, and bonus materials. Supports markdown formatting.",
+			},
 		},
 	],
 };

--- a/src/collections/Reviews.ts
+++ b/src/collections/Reviews.ts
@@ -1,9 +1,17 @@
 import type { CollectionConfig } from "payload";
+import { isSuperAdmin } from "~/lib/access";
 
 export const Reviews: CollectionConfig = {
 	slug: "reviews",
+	access: {
+		read: ({ req }) => isSuperAdmin(req.user),
+		create: ({ req }) => isSuperAdmin(req.user),
+		update: ({ req }) => isSuperAdmin(req.user),
+		delete: ({ req }) => isSuperAdmin(req.user),
+	},
 	admin: {
 		useAsTitle: "description",
+		hidden: ({ user }) => !isSuperAdmin(user),
 	},
 	fields: [
 		{

--- a/src/collections/Tags.ts
+++ b/src/collections/Tags.ts
@@ -1,9 +1,17 @@
 import type { CollectionConfig } from "payload";
+import { isSuperAdmin } from "~/lib/access";
 
 export const Tags: CollectionConfig = {
 	slug: "tags",
+	access: {
+		read: () => true,
+		create: ({ req }) => isSuperAdmin(req.user),
+		update: ({ req }) => isSuperAdmin(req.user),
+		delete: ({ req }) => isSuperAdmin(req.user),
+	},
 	admin: {
 		useAsTitle: "name",
+		hidden: ({ user }) => !isSuperAdmin(user),
 	},
 	fields: [
 		{

--- a/src/collections/Tenants.ts
+++ b/src/collections/Tenants.ts
@@ -1,7 +1,12 @@
 import type { CollectionConfig } from "payload";
+import { isSuperAdmin } from "~/lib/access";
 
 export const Tenants: CollectionConfig = {
 	slug: "tenants",
+	access: {
+		create: ({ req }) => isSuperAdmin(req.user),
+		delete: ({ req }) => isSuperAdmin(req.user),
+	},
 	admin: {
 		useAsTitle: "slug",
 	},
@@ -20,6 +25,9 @@ export const Tenants: CollectionConfig = {
 			type: "text",
 			index: true,
 			required: true,
+			access: {
+				update: ({ req }) => isSuperAdmin(req.user),
+			},
 			unique: true,
 			admin: {
 				description:
@@ -35,15 +43,20 @@ export const Tenants: CollectionConfig = {
 			name: "stripeAccountId",
 			type: "text",
 			required: true,
+			access: {
+				update: ({ req }) => isSuperAdmin(req.user),
+			},
 			admin: {
-				readOnly: true,
+				description: "Stripe account ID associated with your shop",
 			},
 		},
 		{
 			name: "stripeDetailsSubmitted",
 			type: "checkbox",
+			access: {
+				update: ({ req }) => isSuperAdmin(req.user),
+			},
 			admin: {
-				readOnly: true,
 				description:
 					"You cannot create products until you submit your Stripe details",
 			},

--- a/src/lib/access.ts
+++ b/src/lib/access.ts
@@ -1,0 +1,21 @@
+import type { User } from "~/payload-types";
+
+import type { ClientUser } from "payload";
+
+export const isSuperAdmin = (user: User | ClientUser | null) => {
+	return user?.roles?.includes("super-admin");
+};
+
+const isAdmin = (user: User | ClientUser | null) => {
+	return user?.roles?.includes("admin");
+};
+
+const isUser = (user: User | ClientUser | null) => {
+	return user?.roles?.includes("user");
+};
+
+export const access = {
+	isSuperAdmin,
+	isAdmin,
+	isUser,
+};

--- a/src/modules/checkout/server/procedures.ts
+++ b/src/modules/checkout/server/procedures.ts
@@ -26,6 +26,9 @@ export const checkoutRouter = createTRPCRouter({
 			const products = await ctx.payload.find({
 				collection: "products",
 				depth: 2,
+				select: {
+					content: false,
+				},
 				where: {
 					and: [
 						{
@@ -123,6 +126,9 @@ export const checkoutRouter = createTRPCRouter({
 		.query(async ({ ctx, input }) => {
 			const data = await ctx.payload.find({
 				collection: "products",
+				select: {
+					content: false,
+				},
 				depth: 2, // Populate category and image
 				where: {
 					id: {

--- a/src/modules/library/ui/views/product-view.tsx
+++ b/src/modules/library/ui/views/product-view.tsx
@@ -40,9 +40,14 @@ export const ProductView = ({ productId }: ProductViewProps) => {
 					</div>
 
 					<div className="lg:col-span-5">
-						<p className="font-medium italic text-muted-foreground">
-							No special content
-						</p>
+						{data.content ? (
+							// TODO: Rich text
+							<p>{data.content}</p>
+						) : (
+							<p className="font-medium italic text-muted-foreground">
+								No special content
+							</p>
+						)}
 					</div>
 				</div>
 			</section>

--- a/src/modules/products/server/procedures.ts
+++ b/src/modules/products/server/procedures.ts
@@ -23,6 +23,9 @@ export const productsRouter = createTRPCRouter({
 				collection: "products",
 				id: input.id,
 				depth: 2, // load product image, tenant and tenant image
+				select: {
+					content: false,
+				},
 			});
 
 			let isPurchased = false;
@@ -207,6 +210,9 @@ export const productsRouter = createTRPCRouter({
 				sort,
 				page: input.cursor,
 				limit: input.limit,
+				select: {
+					content: false,
+				},
 			});
 
 			const dataWithSummarisedReviews = await getSummarisedReviews(

--- a/src/modules/reviews/servers/procedures.ts
+++ b/src/modules/reviews/servers/procedures.ts
@@ -14,6 +14,9 @@ export const reviewsRouter = createTRPCRouter({
 			const product = await ctx.payload.findByID({
 				collection: "products",
 				id: input.productId,
+				select: {
+					content: false,
+				},
 			});
 
 			if (!product) {
@@ -61,6 +64,9 @@ export const reviewsRouter = createTRPCRouter({
 			const product = await ctx.payload.findByID({
 				collection: "products",
 				id: input.productId,
+				select: {
+					content: false,
+				},
 			});
 
 			if (!product) {

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -169,6 +169,9 @@ export interface Tenant {
    */
   slug: string;
   image?: (string | null) | Media;
+  /**
+   * Stripe account ID associated with your shop
+   */
   stripeAccountId: string;
   /**
    * You cannot create products until you submit your Stripe details
@@ -231,6 +234,10 @@ export interface Product {
   tags?: (string | Tag)[] | null;
   image?: (string | Media)[] | null;
   refundPolicy?: ('30-day' | '14-day' | '7-day' | '3-day' | '1-day' | 'no-refunds') | null;
+  /**
+   * Protected content only visible to customers after purchase. Add product documentation, downloadable files, getting started guides, and bonus materials. Supports markdown formatting.
+   */
+  content?: string | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -254,6 +261,9 @@ export interface Order {
   name: string;
   user: string | User;
   product: string | Product;
+  /**
+   * Stripe checkout session associated with this order
+   */
   stripeCheckoutSessionId: string;
   updatedAt: string;
   createdAt: string;
@@ -419,6 +429,7 @@ export interface ProductsSelect<T extends boolean = true> {
   tags?: T;
   image?: T;
   refundPolicy?: T;
+  content?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -8,6 +8,8 @@ import { multiTenantPlugin } from "@payloadcms/plugin-multi-tenant";
 import { buildConfig } from "payload";
 import sharp from "sharp";
 
+import { isSuperAdmin } from "~/lib/access";
+
 // Import all Collections to use below
 import { Categories } from "./collections/Categories";
 import { Media } from "./collections/Media";
@@ -50,7 +52,7 @@ export default buildConfig({
 			tenantsArrayField:{
 				includeDefaultField:false
 			},
-			userHasAccessToAllTenants:user => Boolean(user?.roles?.includes("super-admin"))
+			userHasAccessToAllTenants:user => isSuperAdmin(user)
 		}),
 		// storage-adapter-placeholder
 	],


### PR DESCRIPTION
- Introduced `isSuperAdmin` utility for role-based access control across collections.
- Updated `Categories`, `Media`, `Orders`, `Products`, `Reviews`, `Tags`, `Tenants`, and `Users` collections to restrict create, update, and delete operations to super admins.
- Added `stripeAccountId` to `Tenant`, `content` to `Product`, and `stripeCheckoutSessionId` to `Order` with appropriate descriptions.
- Modified `payload.config.ts` to utilize the new access control logic.
- Updated UI components to conditionally display content based on user roles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added protected product content that is only visible to customers after purchase, with support for markdown formatting.
  - Admin interface now displays a description for the Stripe checkout session ID in orders.

- **Access Control**
  - Introduced stricter role-based access controls across collections, restricting create, update, and delete operations mainly to super administrators.
  - Admin UI visibility for several collections (Categories, Media, Orders, Reviews, Tags, Users) is now limited to super administrators.

- **Bug Fixes**
  - Sensitive product content is no longer exposed in product and review queries unless appropriate permissions are present.

- **Chores**
  - Centralized user role-checking logic for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->